### PR TITLE
增加可选配置，是否允许子级影响父级联动，默认为允许，即nzAllowParentLinkage默认为true

### DIFF
--- a/lib/components/nz-tree.component.ts
+++ b/lib/components/nz-tree.component.ts
@@ -84,6 +84,7 @@ export class NzTreeComponent implements OnInit, OnChanges {
   @Input() nzNodes: any[];
   @Input() nzCheckable = false;
   @Input() nzAutoExpandParent: boolean | number = false;
+  @Input() nzAllowParentLinkage = false;
   @Input() nzShowLine = false;
   @Input() nzOptions: any;
   @Input() nzShiftSelectedMulti = true;
@@ -183,7 +184,9 @@ export class NzTreeComponent implements OnInit, OnChanges {
       }
       parentLoop(parentNode);
     };
-    parentLoop(node);
+    if(nzAllowParentLinkage){
+        parentLoop(node);
+    }
   }
 
   fireEvent(event: any) {

--- a/lib/components/nz-tree.component.ts
+++ b/lib/components/nz-tree.component.ts
@@ -184,7 +184,7 @@ export class NzTreeComponent implements OnInit, OnChanges {
       }
       parentLoop(parentNode);
     };
-    if(nzAllowParentLinkage){
+    if(this.nzAllowParentLinkage){
         parentLoop(node);
     }
   }

--- a/lib/components/nz-tree.component.ts
+++ b/lib/components/nz-tree.component.ts
@@ -84,7 +84,7 @@ export class NzTreeComponent implements OnInit, OnChanges {
   @Input() nzNodes: any[];
   @Input() nzCheckable = false;
   @Input() nzAutoExpandParent: boolean | number = false;
-  @Input() nzAllowParentLinkage = false;
+  @Input() nzAllowParentLinkage = true;
   @Input() nzShowLine = false;
   @Input() nzOptions: any;
   @Input() nzShiftSelectedMulti = true;


### PR DESCRIPTION
有实际需求: 子级状态变更不影响父级选中状态，所以增加此配置